### PR TITLE
Remove ManageIQ method that was accidentally left in

### DIFF
--- a/lib/active_record/id_regions.rb
+++ b/lib/active_record/id_regions.rb
@@ -154,10 +154,6 @@ module ActiveRecord::IdRegions
   end
   alias_method :region_id, :region_number
 
-  def region_description
-    miq_region.description if miq_region
-  end
-
   def compressed_id
     self.class.compress_id(id)
   end


### PR DESCRIPTION
@jrafanie Please review.

I accidentally left this in and it has to move back to ManageIQ.  The method as is cannot work as miq_region is not defined here.  I will release this as 0.2.0 and then bump in a separate PR on ManageIQ.