### PR TITLE
Deprecate id compression

### DIFF
--- a/lib/active_record/id_regions.rb
+++ b/lib/active_record/id_regions.rb
@@ -79,7 +79,7 @@ module ActiveRecord::IdRegions
 
     def split_id(id)
       return [my_region_number, nil] if id.nil?
-      id = uncompress_id(id)
+      id = ActiveSupport::Deprecation.silence { uncompress_id(id) }
 
       region_number = id_to_region(id)
       short_id      = (region_number == 0) ? id : id % (region_number * rails_sequence_factor)

--- a/lib/active_record/id_regions.rb
+++ b/lib/active_record/id_regions.rb
@@ -92,16 +92,19 @@ module ActiveRecord::IdRegions
     #
 
     def compressed_id?(id)
+      ActiveSupport::Deprecation.warn("compressed_id? is deprecated and will be removed in a future release")
       id.to_s =~ /^#{CID_OR_ID_MATCHER}$/
     end
 
     def compress_id(id)
+      ActiveSupport::Deprecation.warn("compress_id is deprecated and will be removed in a future release")
       return nil if id.nil?
       region_number, short_id = split_id(id)
       (region_number == 0) ? short_id.to_s : "#{region_number}#{COMPRESSED_ID_SEPARATOR}#{short_id}"
     end
 
     def uncompress_id(compressed_id)
+      ActiveSupport::Deprecation.warn("uncompress_id is deprecated and will be removed in a future release")
       return nil if compressed_id.nil?
       compressed_id.to_s =~ RE_COMPRESSED_ID ? ($1.to_i * rails_sequence_factor + $2.to_i) : compressed_id.to_i
     end


### PR DESCRIPTION
Adds a deprecation warning for use of `compressed_id?`, `compress_id`
and `uncompress_id`. `ActiveSupport::Deprecation.deprecate_methods`
did not seem to work (presumable because this is a concern?), so I
elected to add a custom deprecation notice to each method instead.

Important to note: `split_id` uses `uncompress_id` internally, which
is unfortunate, since we don't want to flood the logs with such
deprecation notices unnecessarily. We might want to plan carefully how
we back out that behavior.

@miq-bot add-label technical debt
@miq-bot assign @Fryguy 