### PR TITLE
Fix conflicting pg version

### DIFF
--- a/activerecord-id_regions.gemspec
+++ b/activerecord-id_regions.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activerecord", ">= 5.0", "< 5.2"
   spec.add_dependency "activesupport", ">= 5.0", "< 5.2"
-  spec.add_dependency "pg"
+  spec.add_dependency "pg", "~> 0.18"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Unrestrained this bundles to version 1.0.0 of the pg gem, but it
conflicts with another dependency:

```
Gem::LoadError:
  Specified 'postgresql' for database adapter, but the gem is not loaded. Add `gem 'pg'` to your Gemfile (and ensure its version is at the minimum required by ActiveRecord).
\# ./vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.4/lib/active_record/connection_adapters/connection_specification.rb:188:in `rescue in spec'
\# ./vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.4/lib/active_record/connection_adapters/connection_specification.rb:185:in `spec'
\# ./vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.4/lib/active_record/connection_adapters/abstract/connection_pool.rb:880:in `establish_connection'
\# ./vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.4/lib/active_record/connection_handling.rb:58:in `establish_connection'
\# ./spec/spec_helper.rb:38:in `drop_test_database'
\# ./spec/spec_helper.rb:14:in `block (2 levels) in <top (required)>'
\# ------------------
\# --- Caused by: ---
\# Gem::LoadError:
\#   can't activate pg (~> 0.18), already activated pg-1.0.0. Make sure all dependencies are added to Gemfile.
\#   ./vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.4/lib/active_record/connection_adapters/postgresql_adapter.rb:2:in `<top (required)>'
```

@miq-bot add-label bug
@miq-bot assign @bdunne 