### PR TITLE
Don't use new sequences to determine region

### DIFF
--- a/lib/active_record/id_regions/migration.rb
+++ b/lib/active_record/id_regions/migration.rb
@@ -2,10 +2,10 @@ module ActiveRecord::IdRegions
   module Migration
     def create_table(table_name, options = {})
       options[:id] = :bigserial if options[:id].nil?
+      value = anonymous_class_with_id_regions.rails_sequence_start
       super
       return if options[:id] == false
 
-      value = anonymous_class_with_id_regions.rails_sequence_start
       set_pk_sequence!(table_name, value) unless value == 0
     end
 

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -1,0 +1,24 @@
+describe ActiveRecord::IdRegions::Migration do
+  it "Tests that we get the correct starting sequence on newly created tables when region is determined from sequence" do
+    expect(ENV).to receive(:fetch).with("REGION", nil).and_return(nil)
+    region_number_before = TestRecord.region_number_from_sequence
+    described_class.anonymous_class_with_id_regions.clear_region_cache
+
+    allow(described_class.anonymous_class_with_id_regions.connection).to receive(:select_value).and_wrap_original do |m, arg|
+      if arg == "SELECT relname FROM pg_class WHERE relkind = 'S' LIMIT 1"
+        # HACK the order so that we get the most recently created
+        m.call("SELECT relname FROM pg_class WHERE relkind = 'S' ORDER BY oid DESC LIMIT 1")
+      else
+        m.call(arg)
+      end
+    end
+
+    Class.new(ActiveRecord::Migration[5.0]) do
+      def change
+        create_table :testing_correct_sequence
+      end
+    end.migrate(:up)
+
+    expect(TestRecord.id_to_region(ActiveRecord::Base.connection.select_value("SELECT last_value FROM testing_correct_sequence_id_seq"))).to eq(region_number_before)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,9 +43,25 @@ def create_test_database
   ActiveRecord::Base.establish_connection(:adapter => "postgresql", :database => "postgres")
   ActiveRecord::Base.connection.create_database(DB_NAME)
   ActiveRecord::Base.establish_connection(:adapter => "postgresql", :database => DB_NAME)
-  ActiveRecord::Base.connection.create_table("test_records", :id => :bigserial)
+  with_random_region { CreateTestRecordsTable.migrate(:up) }
 end
+
+def with_random_region
+  old_env = ENV.delete("REGION")
+  ENV["REGION"] = rand(1..99).to_s
+  yield
+ensure
+  ENV["REGION"] = old_env
+end
+
+ActiveRecord::Migration.include(ActiveRecord::IdRegions::Migration)
 
 class TestRecord < ActiveRecord::Base
   include ActiveRecord::IdRegions
+end
+
+class CreateTestRecordsTable < ActiveRecord::Migration[5.0]
+  def change
+    create_table :test_records, :id => :bigserial
+  end
 end


### PR DESCRIPTION
Determine the region number before creating the table (and the new sequence).  Previously, the table (and id sequence) were created before the region was determined, and you could potentially get the sequence from the newly created sequence and use it to determine the region, incorrectly giving you 0.

Luckily I think this would only happen to developers since appliances still have the REGION file and pods had the REGION ENV variable set.  Somehow this frequently happened on Travis.  cc @carbonin @jrafanie 