### PR TITLE
Support rails 5.1 and 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: ruby
 rvm:
-  - '2.3.1'
-  - '2.4.2'
-sudo: false
+ - '2.4.6'
+ - '2.5.5'
 cache: bundler
-before_install: gem install bundler -v 1.14.6
 after_script: bundle exec codeclimate-test-reporter
 notifications:
   webhooks:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ Or install it yourself as:
 
     $ gem install activerecord-id_regions
 
+## Usage
+
+Include the module in your application_record.rb:
+
+```ruby
+include ActiveRecord::IdRegions
+```
+
+Create an initializer with the following:
+
+```ruby
+require 'active_record/id_regions/active_record_migration_patch'
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/activerecord-id_regions.gemspec
+++ b/activerecord-id_regions.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 5.0", "< 5.2"
-  spec.add_dependency "activesupport", ">= 5.0", "< 5.2"
+  spec.add_dependency "activerecord", ">= 5.0", "< 5.3"
+  spec.add_dependency "activesupport", ">= 5.0", "< 5.3"
   spec.add_dependency "pg"
 
   spec.add_development_dependency "bundler"

--- a/lib/active_record/id_regions.rb
+++ b/lib/active_record/id_regions.rb
@@ -1,6 +1,7 @@
 require "active_record"
 require "active_support/concern"
 
+require "active_record/id_regions/compatibility"
 require "active_record/id_regions/migration"
 require "active_record/id_regions/version"
 

--- a/lib/active_record/id_regions/active_record_migration_patch.rb
+++ b/lib/active_record/id_regions/active_record_migration_patch.rb
@@ -1,0 +1,1 @@
+ActiveRecord::Migration::Compatibility.singleton_class.prepend(ActiveRecord::IdRegions::Compatibility)

--- a/lib/active_record/id_regions/compatibility.rb
+++ b/lib/active_record/id_regions/compatibility.rb
@@ -1,0 +1,17 @@
+# Rails 5.1+ changed the default primary key type from integer to bigserial in:
+# https://github.com/rails/rails/pull/26266
+# With this change, they modified the default compatibility layer for versions
+# less than 5.1 to default to integer if not provided.  Since we want our
+# default to be bigint/bigserial for those old migrations, we need to prepend
+# our module on the migration class for old migrations.
+#
+# Because activerecord may introduce create_table methods at various versions in
+# the compatibility stack, we need to prepend the patch at the point in which it
+# retrieves one of the version classes.
+module ActiveRecord::IdRegions
+  module Compatibility
+    def find(*)
+      super.tap { |klass| klass.prepend(ActiveRecord::IdRegions::Migration) }
+    end
+  end
+end

--- a/spec/compatibility_spec.rb
+++ b/spec/compatibility_spec.rb
@@ -1,0 +1,9 @@
+describe ActiveRecord::IdRegions::Compatibility do
+  describe "verifies the ancestors" do
+    migration_versions.each do |migration_version|
+      it "for ActiveRecord::Migration[#{migration_version}]" do
+        expect(ActiveRecord::Migration[migration_version].ancestors.first).to eq(ActiveRecord::IdRegions::Migration)
+      end
+    end
+  end
+end

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -1,24 +1,30 @@
 describe ActiveRecord::IdRegions::Migration do
-  it "Tests that we get the correct starting sequence on newly created tables when region is determined from sequence" do
-    expect(ENV).to receive(:fetch).with("REGION", nil).and_return(nil)
-    region_number_before = TestRecord.region_number_from_sequence
-    described_class.anonymous_class_with_id_regions.clear_region_cache
+  describe "ensures starting sequence on newly created tables" do
+    migration_versions.each do |migration_version|
+      it "for ActiveRecord::Migration[#{migration_version}]" do
+        expect(ENV).to receive(:fetch).with("REGION", nil).and_return(nil)
+        region_number_before = TestRecord.region_number_from_sequence
+        described_class.anonymous_class_with_id_regions.clear_region_cache
 
-    allow(described_class.anonymous_class_with_id_regions.connection).to receive(:select_value).and_wrap_original do |m, arg|
-      if arg == "SELECT relname FROM pg_class WHERE relkind = 'S' LIMIT 1"
-        # HACK the order so that we get the most recently created
-        m.call("SELECT relname FROM pg_class WHERE relkind = 'S' ORDER BY oid DESC LIMIT 1")
-      else
-        m.call(arg)
+        allow(described_class.anonymous_class_with_id_regions.connection).to receive(:select_value).and_wrap_original do |m, arg|
+          if arg == "SELECT relname FROM pg_class WHERE relkind = 'S' LIMIT 1"
+            # HACK the order so that we get the most recently created
+            m.call("SELECT relname FROM pg_class WHERE relkind = 'S' ORDER BY oid DESC LIMIT 1")
+          else
+            m.call(arg)
+          end
+        end
+
+        suppress_migration_messages do
+          Class.new(ActiveRecord::Migration[migration_version]) do
+            def change
+              create_table :testing_correct_sequence
+            end
+          end.migrate(:up)
+        end
+
+        expect(TestRecord.id_to_region(ActiveRecord::Base.connection.select_value("SELECT last_value FROM testing_correct_sequence_id_seq"))).to eq(region_number_before)
       end
     end
-
-    Class.new(ActiveRecord::Migration[5.0]) do
-      def change
-        create_table :testing_correct_sequence
-      end
-    end.migrate(:up)
-
-    expect(TestRecord.id_to_region(ActiveRecord::Base.connection.select_value("SELECT last_value FROM testing_correct_sequence_id_seq"))).to eq(region_number_before)
   end
 end


### PR DESCRIPTION
Rails 5.1+ changed the default primary key type from integer to bigserial in:
https://github.com/rails/rails/pull/26266

With this change, they modified the default compatibility layer for versions
less than 5.1 to default to integer if not provided.  Since we want our
default to be bigint/bigserial for those old migrations, we need to prepend
our module on the migration class for old migrations.

Because activerecord may introduce create_table methods at various versions in
the compatibility stack, we need to prepend the patch at the point in which it
retrieves one of the version classes.