### PR TITLE
Support rails 5.1 by forcing bigserial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: ruby
 rvm:
-  - '2.3.1'
-  - '2.4.2'
-sudo: false
+ - '2.4.6'
+ - '2.5.5'
 cache: bundler
-before_install: gem install bundler -v 1.14.6
 after_script: bundle exec codeclimate-test-reporter
 notifications:
   webhooks:

--- a/activerecord-id_regions.gemspec
+++ b/activerecord-id_regions.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 5.0", "< 5.2"
-  spec.add_dependency "activesupport", ">= 5.0", "< 5.2"
+  spec.add_dependency "activerecord", ">= 5.0", "< 5.3"
+  spec.add_dependency "activesupport", ">= 5.0", "< 5.3"
   spec.add_dependency "pg"
 
   spec.add_development_dependency "bundler"

--- a/lib/active_record/id_regions/migration.rb
+++ b/lib/active_record/id_regions/migration.rb
@@ -1,7 +1,7 @@
 module ActiveRecord::IdRegions
   module Migration
     def create_table(table_name, options = {})
-      options[:id] = :bigserial if options[:id].nil?
+      options[:id] = :bigserial unless options[:id] == false
       value = anonymous_class_with_id_regions.rails_sequence_start
       super
       return if options[:id] == false

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -1,24 +1,71 @@
 describe ActiveRecord::IdRegions::Migration do
-  it "Tests that we get the correct starting sequence on newly created tables when region is determined from sequence" do
-    expect(ENV).to receive(:fetch).with("REGION", nil).and_return(nil)
-    region_number_before = TestRecord.region_number_from_sequence
-    described_class.anonymous_class_with_id_regions.clear_region_cache
+  migration_versions.each do |version|
+    it "Ensures starting sequence on newly created tables for #{version} migrations" do
+      expect(ENV).to receive(:fetch).with("REGION", nil).and_return(nil)
+      region_number_before = TestRecord.region_number_from_sequence
+      described_class.anonymous_class_with_id_regions.clear_region_cache
 
-    allow(described_class.anonymous_class_with_id_regions.connection).to receive(:select_value).and_wrap_original do |m, arg|
-      if arg == "SELECT relname FROM pg_class WHERE relkind = 'S' LIMIT 1"
-        # HACK the order so that we get the most recently created
-        m.call("SELECT relname FROM pg_class WHERE relkind = 'S' ORDER BY oid DESC LIMIT 1")
-      else
-        m.call(arg)
+      allow(described_class.anonymous_class_with_id_regions.connection).to receive(:select_value).and_wrap_original do |m, arg|
+        if arg == "SELECT relname FROM pg_class WHERE relkind = 'S' LIMIT 1"
+          # HACK: the order so that we get the most recently created
+          m.call("SELECT relname FROM pg_class WHERE relkind = 'S' ORDER BY oid DESC LIMIT 1")
+        else
+          m.call(arg)
+        end
       end
+
+      Class.new(ActiveRecord::Migration[version]) do
+        def change
+          create_table :testing_correct_sequence
+        end
+      end.migrate(:up)
+
+      expect(TestRecord.id_to_region(ActiveRecord::Base.connection.select_value("SELECT last_value FROM testing_correct_sequence_id_seq"))).to eq(region_number_before)
     end
 
-    Class.new(ActiveRecord::Migration[5.0]) do
-      def change
-        create_table :testing_correct_sequence
-      end
-    end.migrate(:up)
+    context "Tests create_table for #{version} migrations" do
+      let(:klass) { Class.new(ActiveRecord::Base) }
 
-    expect(TestRecord.id_to_region(ActiveRecord::Base.connection.select_value("SELECT last_value FROM testing_correct_sequence_id_seq"))).to eq(region_number_before)
+      it "id => false, creates no id column" do
+        Class.new(ActiveRecord::Migration[version]) do
+          def change
+            create_table :testing_create_table_id_false, :id => false do |t|
+              t.string "name"
+            end
+          end
+        end.migrate(:up)
+
+        klass.table_name = :testing_create_table_id_false
+        expect(klass.attribute_names.sort).to eq(%w[name])
+      end
+
+      it "implicit id, creates bigserial id" do
+        Class.new(ActiveRecord::Migration[version]) do
+          def change
+            create_table :testing_create_table_implicit_id do |t|
+              t.string "name"
+            end
+          end
+        end.migrate(:up)
+
+        klass.table_name = :testing_create_table_implicit_id
+        expect(klass.attribute_names.sort).to eq(%w[id name])
+        expect(ActiveRecord::Base.connection.select_value("SELECT last_value FROM #{klass.table_name}_id_seq")).to be > TestRecord::DEFAULT_RAILS_SEQUENCE_FACTOR
+      end
+
+      it "id => integer, creates bigserial id" do
+        Class.new(ActiveRecord::Migration[version]) do
+          def change
+            create_table :testing_create_table_integer_id, :id => :integer do |t|
+              t.string "name"
+            end
+          end
+        end.migrate(:up)
+
+        klass.table_name = :testing_create_table_integer_id
+        expect(klass.attribute_names.sort).to eq(%w[id name])
+        expect(ActiveRecord::Base.connection.select_value("SELECT last_value FROM #{klass.table_name}_id_seq")).to be > TestRecord::DEFAULT_RAILS_SEQUENCE_FACTOR
+      end
+    end
   end
 end

--- a/spec/migration_spec.rb
+++ b/spec/migration_spec.rb
@@ -14,11 +14,13 @@ describe ActiveRecord::IdRegions::Migration do
         end
       end
 
-      Class.new(ActiveRecord::Migration[version]) do
-        def change
-          create_table :testing_correct_sequence
-        end
-      end.migrate(:up)
+      suppress_migration_messages do
+        Class.new(ActiveRecord::Migration[version]) do
+          def change
+            create_table :testing_correct_sequence
+          end
+        end.migrate(:up)
+      end
 
       expect(TestRecord.id_to_region(ActiveRecord::Base.connection.select_value("SELECT last_value FROM testing_correct_sequence_id_seq"))).to eq(region_number_before)
     end
@@ -27,26 +29,30 @@ describe ActiveRecord::IdRegions::Migration do
       let(:klass) { Class.new(ActiveRecord::Base) }
 
       it "id => false, creates no id column" do
-        Class.new(ActiveRecord::Migration[version]) do
-          def change
-            create_table :testing_create_table_id_false, :id => false do |t|
-              t.string "name"
+        suppress_migration_messages do
+          Class.new(ActiveRecord::Migration[version]) do
+            def change
+              create_table :testing_create_table_id_false, :id => false do |t|
+                t.string "name"
+              end
             end
-          end
-        end.migrate(:up)
+          end.migrate(:up)
+        end
 
         klass.table_name = :testing_create_table_id_false
         expect(klass.attribute_names.sort).to eq(%w[name])
       end
 
       it "implicit id, creates bigserial id" do
-        Class.new(ActiveRecord::Migration[version]) do
-          def change
-            create_table :testing_create_table_implicit_id do |t|
-              t.string "name"
+        suppress_migration_messages do
+          Class.new(ActiveRecord::Migration[version]) do
+            def change
+              create_table :testing_create_table_implicit_id do |t|
+                t.string "name"
+              end
             end
-          end
-        end.migrate(:up)
+          end.migrate(:up)
+        end
 
         klass.table_name = :testing_create_table_implicit_id
         expect(klass.attribute_names.sort).to eq(%w[id name])
@@ -54,13 +60,15 @@ describe ActiveRecord::IdRegions::Migration do
       end
 
       it "id => integer, creates bigserial id" do
-        Class.new(ActiveRecord::Migration[version]) do
-          def change
-            create_table :testing_create_table_integer_id, :id => :integer do |t|
-              t.string "name"
+        suppress_migration_messages do
+          Class.new(ActiveRecord::Migration[version]) do
+            def change
+              create_table :testing_create_table_integer_id, :id => :integer do |t|
+                t.string "name"
+              end
             end
-          end
-        end.migrate(:up)
+          end.migrate(:up)
+        end
 
         klass.table_name = :testing_create_table_integer_id
         expect(klass.attribute_names.sort).to eq(%w[id name])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,7 +43,7 @@ def create_test_database
   ActiveRecord::Base.establish_connection(:adapter => "postgresql", :database => "postgres")
   ActiveRecord::Base.connection.create_database(DB_NAME)
   ActiveRecord::Base.establish_connection(:adapter => "postgresql", :database => DB_NAME)
-  with_random_region { CreateTestRecordsTable.migrate(:up) }
+  suppress_migration_messages { with_random_region { CreateTestRecordsTable.migrate(:up) } }
 end
 
 def with_random_region
@@ -55,6 +55,13 @@ ensure
 end
 
 ActiveRecord::Migration.include(ActiveRecord::IdRegions::Migration)
+
+def suppress_migration_messages
+  save, ActiveRecord::Migration.verbose = ActiveRecord::Migration.verbose, false
+  yield
+ensure
+  ActiveRecord::Migration.verbose = save
+end
 
 def migration_versions
   [5.2, 5.1, 5.0, 4.2].select { |v| ActiveRecord::VERSION::STRING >= v.to_s }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -56,6 +56,10 @@ end
 
 ActiveRecord::Migration.include(ActiveRecord::IdRegions::Migration)
 
+def migration_versions
+  [5.2, 5.1, 5.0, 4.2].select { |v| ActiveRecord::VERSION::STRING >= v.to_s }
+end
+
 class TestRecord < ActiveRecord::Base
   include ActiveRecord::IdRegions
 end


### PR DESCRIPTION
Alternative to #12 

This PR doesn't require monkey patching shenanigans and instead asserts that bigserial is required for any id columns you use with this gem.  Support for `:id => false` passed to `create_table` is still honored but any other value for `:id` will be ignored and bigserial will be used.

Backstory:

Rails 5.1+ changed the default primary key type from integer to bigserial in:
rails/rails#26266

With this change, they modified the default compatibility layer for migration
versions less than 5.1 to default to integer if not provided.  Since we need
bigserial ids for region support, we need 4.2 and 5.0 versioned migrations
to also use bigserial id columns unless they explicitly say id => false
for tables without id columns.