### PR TITLE
don't list the default distro in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: xenial
 language: ruby
 rvm:
  - '2.4.6'


### PR DESCRIPTION
listing the distro on this repo isn’t necessary and Jason says we should only do so when it’s required which is probably also not here

