### PR TITLE
Make last positional argument explicit (add ruby 3 support, drop EOL 2.5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: ruby
 rvm:
 - 2.6.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 rvm:
-- 2.5.8
-- 2.6.6
+- 2.6.8
+- 2.7.4
+- 3.0.1
 cache: bundler
 addons:
   postgresql: '10'

--- a/lib/active_record/id_regions/migration.rb
+++ b/lib/active_record/id_regions/migration.rb
@@ -2,7 +2,7 @@ module ActiveRecord::IdRegions
   module Migration
     ALLOWED_ID_VALUES = [false, :uuid, "uuid"].freeze
 
-    def create_table(table_name, options = {})
+    def create_table(table_name, **options)
       options[:id] = :bigserial unless ALLOWED_ID_VALUES.include?(options[:id])
       value = anonymous_class_with_id_regions.rails_sequence_start
       super


### PR DESCRIPTION
Ruby 3 drops support for automatic conversion.

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

Fixes the following error on ruby 3 when running the tests:

ArgumentError:
  wrong number of arguments (given 2, expected 1)