### PR TITLE
Use core minimum but allow 7.0/7.1/7.2 since core sets upper limit (breaking change)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,10 +15,17 @@ jobs:
         - '2.7'
         - '3.0'
         - '3.1'
+        - '3.2'
+        - '3.3'
         rails-version:
-        - '6.0'
-        - '6.1'
         - '7.0'
+        - '7.1'
+        - '7.2'
+        exclude:
+        - ruby-version: '2.7'
+          rails-version: '7.2'
+        - ruby-version: '3.0'
+          rails-version: '7.2'
     services:
       postgres:
         image: manageiq/postgresql:13

--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,12 @@ gemspec
 
 minimum_version =
   case ENV['TEST_RAILS_VERSION']
-  when "6.0"
-    "~>6.0.4"
-  when "7.0"
-    "~>7.0.8"
+  when "7.2"
+    "~>7.2.1"
+  when "7.1"
+    "~>7.1.4"
   else
-    "~>6.1.4"
+    "~>7.0.8"
   end
 
 gem "activerecord", minimum_version

--- a/activerecord-id_regions.gemspec
+++ b/activerecord-id_regions.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.name          = "activerecord-id_regions"
   spec.version       = ActiveRecord::IdRegions::VERSION
   spec.authors       = ["ManageIQ Developers"]
-
+  spec.metadata['rubygems_mfa_required'] = 'true'
   spec.summary       = %q{ActiveRecord extension to allow partitioning ids into regions, for merge replication purposes}
   spec.description   = %q{ActiveRecord extension to allow partitioning ids into regions, for merge replication purposes}
   spec.homepage      = "https://github.com/ManageIQ/activerecord-id_regions"

--- a/activerecord-id_regions.gemspec
+++ b/activerecord-id_regions.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord",  ">= 5.0", "<7.1"
-  spec.add_dependency "activesupport", ">= 5.0", "<7.1"
+  spec.add_dependency "activerecord",  ">= 7.0.8", "<8.0"
+  spec.add_dependency "activesupport", ">= 7.0.8", "<8.0"
   spec.add_dependency "pg"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
Drop end of life rails and add new versions.
Ensure we're testing and supporting community supported
versions.

Drop:

rails 6.0
rails 6.1

Add:

ruby 3.2
ruby 3.3
rails 7.1
rails 7.2

Note: ruby 2.7, and 3.0 are not difficult to keep maintaining, this repo has fast tests and
rails 7 is the minimum and it requires ruby 2.7+ so it's important to target the rubies supported
by the dependency this repo tracks most closely.