### PR TITLE
Add Rails 8 support, drop EOL ruby and rails versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,18 +19,10 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '2.7'
-        - '3.0'
-        - '3.1'
         - '3.2'
         - '3.3'
         rails-version:
         - '7.2'
-        exclude:
-        - ruby-version: '2.7'
-          rails-version: '7.2'
-        - ruby-version: '3.0'
-          rails-version: '7.2'
     services:
       postgres:
         image: manageiq/postgresql:13

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
         - '3.3'
         rails-version:
         - '7.2'
+        - '8.0'
     services:
       postgres:
         image: manageiq/postgresql:13

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,8 +25,6 @@ jobs:
         - '3.2'
         - '3.3'
         rails-version:
-        - '7.0'
-        - '7.1'
         - '7.2'
         exclude:
         - ruby-version: '2.7'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Add support for rails 8.0
+- Drop support for end of life versions:
+  - rails 7.0, 7.1
+  - ruby 2.7, 3.0, and 3.1
+
 ## [0.5.0] - 2024-10-10
 ### Changed
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,8 @@ gemspec
 
 minimum_version =
   case ENV['TEST_RAILS_VERSION']
-  when "7.2"
-    "~>7.2.1"
-  when "7.1"
-    "~>7.1.4"
   else
-    "~>7.0.8"
+    "~>7.2.1"
   end
 
 gem "activerecord", minimum_version

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,10 @@ gemspec
 
 minimum_version =
   case ENV['TEST_RAILS_VERSION']
+  when "8.0"
+    "~>8.0.4"
   else
-    "~>7.2.1"
+    "~>7.2.3"
   end
 
 gem "activerecord", minimum_version

--- a/activerecord-id_regions.gemspec
+++ b/activerecord-id_regions.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 3.2"
-  spec.add_dependency "activerecord",  ">= 7.2.3", "<8.0"
-  spec.add_dependency "activesupport", ">= 7.2.3", "<8.0"
+  spec.add_dependency "activerecord",  ">= 7.2.3", "<8.1"
+  spec.add_dependency "activesupport", ">= 7.2.3", "<8.1"
   spec.add_dependency "pg"
 
   spec.add_development_dependency "bundler"

--- a/activerecord-id_regions.gemspec
+++ b/activerecord-id_regions.gemspec
@@ -20,11 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "concurrent-ruby", "< 1.3.5" # Temporary pin down as concurrent-ruby 1.3.5 breaks Rails 7.0, and rails-core doesn't
-                                                   # plan to ship a new 7.0 to fix it. See https://github.com/rails/rails/pull/54264
-
-  spec.add_dependency "activerecord",  ">= 7.0.8.7", "<8.0"
-  spec.add_dependency "activesupport", ">= 7.0.8.7", "<8.0"
+  spec.add_dependency "activerecord",  ">= 7.2.3", "<8.0"
+  spec.add_dependency "activesupport", ">= 7.2.3", "<8.0"
   spec.add_dependency "pg"
 
   spec.add_development_dependency "bundler"

--- a/activerecord-id_regions.gemspec
+++ b/activerecord-id_regions.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 3.2"
   spec.add_dependency "activerecord",  ">= 7.2.3", "<8.0"
   spec.add_dependency "activesupport", ">= 7.2.3", "<8.0"
   spec.add_dependency "pg"


### PR DESCRIPTION
* Support rails 8.0
* Drop EOL rubies 2.7-3.1
* Drop EOL rails 7.0 and 7.1